### PR TITLE
Use correct param location for associateLead method

### DIFF
--- a/src/service.json
+++ b/src/service.json
@@ -138,7 +138,7 @@
             "uri": "leads/{id}/associate.json",
             "parameters": {
                 "id": {"location": "uri"},
-                "cookie": {"location": "json"}
+                "cookie": {"location": "query"}
             },
             "responseClass": "CSD\\Marketo\\Response\\AssociateLeadResponse"
         },


### PR DESCRIPTION
Hey Daniel,

I was incorrectly defining the cookie param. This seems to fix it!
