### PR TITLE
Adding client config to set request Content-Type to 'application/json'.

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -71,6 +71,7 @@ class Client extends GuzzleClient
         $client = new self($restUrl, $config);
         $client->addSubscriber($auth);
         $client->setDescription(ServiceDescription::factory(__DIR__ . '/service.json'));
+        $client->setDefaultOption('headers/Content-Type', 'application/json');
 
         return $client;
     }


### PR DESCRIPTION
Forces the Guzzle client to use a Content-Type of 'application/json'. As per this issue: https://github.com/dchesterton/marketo-rest-api/issues/12 