### PR TITLE
Correct removedLeadsFromList method internal command parameter.

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -477,7 +477,7 @@ class Client extends GuzzleClient
         $args['listId'] = $listId;
         $args['id'] = (array) $leads;
 
-        return $this->getResult('removeLeadsToList', $args, true, $returnRaw);
+        return $this->getResult('removeLeadsFromList', $args, true, $returnRaw);
     }
 
     /**


### PR DESCRIPTION
### Requirements

Fix incorrect command parameter in the removeLeadsFromList method. 
### Changes
- [x] Replace `removeLeadsToList` with `removeLeadsFromList`
