### PR TITLE
Provides getErrors() method for Response class, so you can work with array of errors form response.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .DS_Store
+.idea

--- a/src/Response.php
+++ b/src/Response.php
@@ -78,6 +78,15 @@ class Response implements ResponseClassInterface
     }
 
     /**
+     * Returns Errors from marketo as array.
+     *
+     * @return array|null
+     */
+    public function getErrors() {
+        return (isset($this->data['errors']) && count($this->data['errors'])) ? $this->data['errors'] : null;
+    }
+
+    /**
      * {@inheritdoc}
      */
     public static function fromCommand(OperationCommand $command)


### PR DESCRIPTION
I's great to have array or errors, so you can parse errors messages and perform additional actions. As example: you pass some non-existing (in some cases) custom fields in getLeadByFilterType request, marketo will returns 2 errors. You can parse them, delete from request and try again, but you need array of error messages to get incorrect field names.
