### PR TITLE
Add support for GetLeadActivities call

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -629,6 +629,13 @@ class Client extends GuzzleClient
         return $this->getResult('getLeadChanges', $args, true, $returnRaw);
     }
 
+    public function getLeadActivities($nextPageToken, $args = array(), $returnRaw = false)
+    {
+        $args['nextPageToken'] = $nextPageToken;
+
+        return $this->getResult('getLeadActivities', $args, true, $returnRaw);
+    }
+
     /**
      * Update an editable section in an email
      *

--- a/src/Response/GetLeadActivities.php
+++ b/src/Response/GetLeadActivities.php
@@ -1,0 +1,22 @@
+<?php
+namespace CSD\Marketo\Response;
+
+use CSD\Marketo\Response as Response;
+
+/**
+ * Response for the getLead and getLeadByFilterType API method.
+ *
+ * @author Roberto Espinoza <roberto.espinoza@tamago-db.com>
+ */
+class GetLeadActivities extends Response
+{
+	public function getActivities()
+	{
+        if ($this->isSuccess()) {
+            $result = $this->getResult();
+            return $result;
+        }
+
+        return null;
+	}
+}

--- a/src/service.json
+++ b/src/service.json
@@ -85,6 +85,20 @@
             },
             "responseClass": "CSD\\Marketo\\Response\\GetLeadsResponse"
         },
+        "getLeadActivities": {
+            "httpMethod": "GET",
+            "uri": "activities.json",
+            "parameters": {
+                "nextPageToken": {"location": "query"},
+                "batchSize": {"location": "query"},
+                "nextPageToken": {"location": "query"},
+                "listId": {"location": "query"},
+                "leadIds": {"location": "query"},
+                "activityTypeIds": {"location": "query"},
+                "assetIds": {"location": "query"}
+            },
+            "responseClass": "CSD\\Marketo\\Response\\GetLeadActivities"
+        },
         "isMemberOfList": {
             "httpMethod": "GET",
             "uri": "lists/{listId}/leads/ismember.json",


### PR DESCRIPTION
The GetLeadActivities call is cirrently missing from the service listing. 
That has been added, as well as support in the client library and a cooresponding response object.